### PR TITLE
Update repository to point to GitHub page

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.5",
   "description": "A TypeScript / JavaScript / Node.js implementation of JSON Schema Language",
   "main": "lib/index.js",
-  "repository": "ssh://git@github.com/json-schema-language/json-schema-language-typescript.git",
+  "repository": "https://github.com/json-schema-language/json-schema-language-typescript",
   "author": "Ulysse Carion <ulyssecarion@gmail.com>",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
Currently NPM isn't listing the repository because it expects that repository is a URL. Updating this will just make it a little easier for folks to get back to the project.